### PR TITLE
Sync soversion in meson with autotools build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('openh264', ['c', 'cpp'],
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])
 
-major_version = '4'
+major_version = '5'
 
 cpp = meson.get_compiler('cpp')
 


### PR DESCRIPTION
Soversion in autotools build was bumped to 5,
but the major version in meson build was not bumped at the same time.
Sync soversion in meson.